### PR TITLE
added parser to .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "parser": "babel-eslint",
   "extends": "airbnb",
   rules: {
     "react/prefer-stateless-function": 0


### PR DESCRIPTION
As we know, we are using ES6 coding standard. So it is necessary to configure babel-eslint as parser for eslint. Otherwise, it will raise syntax error.

[issue#04](https://github.com/Codebrahma/react-redux-boilerplate/issues/4)
