### PR TITLE
added react-css-modules

### DIFF
--- a/app/modules/Core/components/main.js
+++ b/app/modules/Core/components/main.js
@@ -9,6 +9,9 @@
 
 import React from 'react';
 import BaseComponent from './baseComponent';
+/** Modular css in react component */
+import cssmodules from 'react-css-modules';
+import styles from '../styles/main.scss';
 
 class App extends BaseComponent {
 
@@ -27,4 +30,4 @@ App.propTypes = {
   children: React.PropTypes.node,
 };
 
-export default App;
+export default cssmodules(App, styles);

--- a/app/modules/Core/styles/main.scss
+++ b/app/modules/Core/styles/main.scss
@@ -1,0 +1,9 @@
+// Just to demostrate react-css-modules & autoprefixer-loader
+
+.container {
+  margin: 20px;
+  display: flex;
+  .inner-container {
+    padding: 40px;
+  }
+}

--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -30,7 +30,7 @@ module.exports = (options) => ({
       ],
     }, {
       test: /\.scss$/,
-      loader: 'style!css!sass',
+      loader: 'style!css?modules&importLoaders=1&localIdentName=[path]___[name]__[local]___[hash:base64:5]!autoprefixer-loader!sass',
     }, {
       test: /\.html$/,
       loader: 'html-loader',

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "node-sass": "^3.9.0",
     "offline-plugin": "^3.4.2",
     "react": "15.3.0",
+    "react-css-modules": "^3.7.10",
     "react-dom": "15.3.0",
     "react-helmet": "3.1.0",
     "react-pure-render": "^1.0.2",
@@ -50,6 +51,7 @@
     "reselect": "2.5.3"
   },
   "devDependencies": {
+    "autoprefixer-loader": "^3.2.0",
     "babel-cli": "^6.11.4",
     "babel-core": "6.11.4",
     "babel-eslint": "6.1.2",


### PR DESCRIPTION
- Added [react-css-modules](https://github.com/gajus/react-css-modules) to implement automatic mapping of CSS modules in component.
- Added [autoprefixer-loader](https://github.com/passy/autoprefixer-loader) to make cross-browser compatibility 
