### PR TITLE
Stylelint npm script fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "npm run lint:js && npm run lint:css",
     "lint:eslint": "eslint --ignore-path .gitignore",
     "lint:js": "npm run lint:eslint -- . ",
-    "lint:css": "stylelint ./app/*.scss ./app/**/**/.scss ./app/**/**/**/*.scss",
+    "lint:css": "stylelint './app/**/**/*.scss'",
     "lint:staged": "lint-staged"
   },
   "dependencies": {


### PR DESCRIPTION
There was a bug in our `npm run lint:css`
it wasn't checking the files deep inside the file structure, its fixed now

solution derived from [https://github.com/stylelint/stylelint/issues/953](https://github.com/stylelint/stylelint/issues/953)